### PR TITLE
Automatically select order by minimizing peak mu error

### DIFF
--- a/examples/3_example_dk_iter_custom.py
+++ b/examples/3_example_dk_iter_custom.py
@@ -7,7 +7,53 @@ from matplotlib import pyplot as plt
 import dkpy
 
 
-def example_dk_iter_list_order():
+class MyDkIter(dkpy.DkIteration):
+    """Custom D-K iteration class with interactive order selection."""
+
+    def _get_fit_order(
+        self,
+        iteration,
+        omega,
+        mu_omega,
+        D_omega,
+        P,
+        K,
+        block_structure,
+    ):
+        d_info = []
+        for fit_order in range(5):
+            D_fit, D_fit_inv = self.transfer_function_fit.fit(
+                omega,
+                D_omega,
+                order=fit_order,
+                block_structure=block_structure,
+            )
+            d_info.append(
+                dkpy.DScaleFitInfo.create_from_fit(
+                    omega,
+                    mu_omega,
+                    D_omega,
+                    P,
+                    K,
+                    D_fit,
+                    D_fit_inv,
+                    block_structure,
+                )
+            )
+        fig, ax = plt.subplots()
+        dkpy.plot_mu(d_info[0], ax=ax, plot_kw=dict(label="true"), hide="mu_fit_omega")
+        for i, ds in enumerate(d_info):
+            dkpy.plot_mu(ds, ax=ax, plot_kw=dict(label=f"order={i}"), hide="mu_omega")
+        print("Close plot to continue...")
+        plt.show()
+        selected_order_str = input("Select order (<Enter> to end iteration): ")
+        if selected_order_str == "":
+            return None
+        else:
+            return int(selected_order_str)
+
+
+def example_dk_iter_custom():
     """D-K iteration with fixed number of iterations and fit order."""
     # Plant
     G0 = np.array(
@@ -66,7 +112,7 @@ def example_dk_iter_list_order():
     n_y = 2
     n_u = 2
 
-    dk_iter = dkpy.DkIterListOrder(
+    dk_iter = MyDkIter(
         controller_synthesis=dkpy.HinfSynLmi(
             lmi_strictness=1e-7,
             solver_params=dict(
@@ -85,12 +131,6 @@ def example_dk_iter_list_order():
             ),
         ),
         transfer_function_fit=dkpy.TfFitSlicot(),
-        # fit_orders=[4, 4, 4],
-        fit_orders=[
-            np.diag([4, 4, 0, 0]),
-            np.diag([4, 4, 0, 0]),
-            np.diag([4, 4, 0, 0]),
-        ],
     )
 
     omega = np.logspace(-3, 3, 61)
@@ -117,4 +157,4 @@ def example_dk_iter_list_order():
 
 
 if __name__ == "__main__":
-    example_dk_iter_list_order()
+    example_dk_iter_custom()

--- a/examples/4_example_dk_iter_auto_order.py
+++ b/examples/4_example_dk_iter_auto_order.py
@@ -7,53 +7,7 @@ from matplotlib import pyplot as plt
 import dkpy
 
 
-class MyDkIter(dkpy.DkIteration):
-    """Custom D-K iteration class with interactive order selection."""
-
-    def _get_fit_order(
-        self,
-        iteration,
-        omega,
-        mu_omega,
-        D_omega,
-        P,
-        K,
-        block_structure,
-    ):
-        d_info = []
-        for fit_order in range(5):
-            D_fit, D_fit_inv = self.transfer_function_fit.fit(
-                omega,
-                D_omega,
-                order=fit_order,
-                block_structure=block_structure,
-            )
-            d_info.append(
-                dkpy.DScaleFitInfo.create_from_fit(
-                    omega,
-                    mu_omega,
-                    D_omega,
-                    P,
-                    K,
-                    D_fit,
-                    D_fit_inv,
-                    block_structure,
-                )
-            )
-        fig, ax = plt.subplots()
-        dkpy.plot_mu(d_info[0], ax=ax, plot_kw=dict(label="true"), hide="mu_fit_omega")
-        for i, ds in enumerate(d_info):
-            dkpy.plot_mu(ds, ax=ax, plot_kw=dict(label=f"order={i}"), hide="mu_omega")
-        print("Close plot to continue...")
-        plt.show()
-        selected_order_str = input("Select order (<Enter> to end iteration): ")
-        if selected_order_str == "":
-            return None
-        else:
-            return int(selected_order_str)
-
-
-def example_dk_iter_fixed_order():
+def example_dk_iter_auto_order():
     """D-K iteration with fixed number of iterations and fit order."""
     # Plant
     G0 = np.array(
@@ -112,7 +66,7 @@ def example_dk_iter_fixed_order():
     n_y = 2
     n_u = 2
 
-    dk_iter = MyDkIter(
+    dk_iter = dkpy.DkIterAutoOrder(
         controller_synthesis=dkpy.HinfSynLmi(
             lmi_strictness=1e-7,
             solver_params=dict(
@@ -131,6 +85,10 @@ def example_dk_iter_fixed_order():
             ),
         ),
         transfer_function_fit=dkpy.TfFitSlicot(),
+        max_mu=1,
+        max_mu_fit_error=1e-2,
+        max_iterations=None,
+        max_fit_order=None,
     )
 
     omega = np.logspace(-3, 3, 61)
@@ -157,4 +115,4 @@ def example_dk_iter_fixed_order():
 
 
 if __name__ == "__main__":
-    example_dk_iter_fixed_order()
+    example_dk_iter_auto_order()

--- a/examples/4_example_dk_iter_auto_order.py
+++ b/examples/4_example_dk_iter_auto_order.py
@@ -87,8 +87,8 @@ def example_dk_iter_auto_order():
         transfer_function_fit=dkpy.TfFitSlicot(),
         max_mu=1,
         max_mu_fit_error=1e-2,
-        max_iterations=None,
-        max_fit_order=None,
+        max_iterations=3,
+        max_fit_order=4,
     )
 
     omega = np.logspace(-3, 3, 61)

--- a/src/dkpy/dk_iteration.py
+++ b/src/dkpy/dk_iteration.py
@@ -448,6 +448,7 @@ class DkIterAutoOrder(DkIteration):
         K: control.StateSpace,
         block_structure: np.ndarray,
     ) -> Optional[Union[int, np.ndarray]]:
+        print(f"{iteration}")  # TODO
         # Check termination conditions
         if (self.max_iterations is not None) and (iteration >= self.max_iterations):
             # TODO LOG
@@ -475,13 +476,14 @@ class DkIterAutoOrder(DkIteration):
                 D_fit_inv,
                 block_structure,
             )
-            error = mu_omega - d_scale_fit_info.mu_fit_omega
-            relative_error = np.max(error / np.max(mu_omega))
+            error = np.abs(mu_omega - d_scale_fit_info.mu_fit_omega)
+            relative_error = np.max(error / np.max(np.abs(mu_omega)))
+            print(f"    {fit_order}: {relative_error}")  # TODO
             relative_errors.append(relative_error)
             if (self.max_fit_order is not None) and (fit_order >= self.max_fit_order):
                 # TODO LOG
                 return int(np.argmin(relative_errors))
-            if relative_error > self.max_mu_fit_error:
+            if relative_error >= self.max_mu_fit_error:
                 fit_order += 1
             else:
                 return fit_order

--- a/src/dkpy/dk_iteration.py
+++ b/src/dkpy/dk_iteration.py
@@ -5,6 +5,7 @@ __all__ = [
     "DkIteration",
     "DkIterFixedOrder",
     "DkIterListOrder",
+    "DkIterAutoOrder",
 ]
 
 import abc
@@ -395,6 +396,95 @@ class DkIterListOrder(DkIteration):
             return self.fit_orders[iteration]
         else:
             return None
+
+
+class DkIterAutoOrder(DkIteration):
+    """D-K iteration with a fixed list of fit orders."""
+
+    def __init__(
+        self,
+        controller_synthesis: controller_synthesis.ControllerSynthesis,
+        structured_singular_value: structured_singular_value.StructuredSingularValue,
+        transfer_function_fit: fit_transfer_functions.TransferFunctionFit,
+        max_mu: float = 1,
+        max_mu_fit_error: float = 1e-2,
+        max_iterations: Optional[int] = None,
+        max_fit_order: Optional[int] = None,
+    ):
+        """Instantiate :class:`DkIterListOrder`.
+
+        Parameters
+        ----------
+        controller_synthesis : dkpy.ControllerSynthesis
+            A controller synthesis object.
+        structured_singular_value : dkpy.StructuredSingularValue
+            A structured singular value computation object.
+        transfer_function_fit : dkpy.TransferFunctionFit
+            A transfer function fit object.
+        max_mu : float
+            Maximum acceptable structured singular value.
+        max_mu_fit_error : float
+            Maximum relative fit error for structured singular value.
+        max_iterations : Optional[int]
+            Maximum number of iterations. If ``None``, there is no upper limit.
+        max_fit_order : Optional[int]
+            Maximum fit order. If ``None``, there is no upper limit.
+        """
+        self.controller_synthesis = controller_synthesis
+        self.structured_singular_value = structured_singular_value
+        self.transfer_function_fit = transfer_function_fit
+        self.max_mu = max_mu
+        self.max_mu_fit_error = max_mu_fit_error
+        self.max_iterations = max_iterations
+        self.max_fit_order = max_fit_order
+
+    def _get_fit_order(
+        self,
+        iteration: int,
+        omega: np.ndarray,
+        mu_omega: np.ndarray,
+        D_omega: np.ndarray,
+        P: control.StateSpace,
+        K: control.StateSpace,
+        block_structure: np.ndarray,
+    ) -> Optional[Union[int, np.ndarray]]:
+        # Check termination conditions
+        if (self.max_iterations is not None) and (iteration >= self.max_iterations):
+            # TODO LOG
+            return None
+        if np.max(mu_omega) < self.max_mu:
+            # TODO LOG
+            return None
+        # Determine fit order
+        fit_order = 0
+        relative_errors = []
+        while True:
+            D_fit, D_fit_inv = self.transfer_function_fit.fit(
+                omega,
+                D_omega,
+                order=fit_order,
+                block_structure=block_structure,
+            )
+            d_scale_fit_info = DScaleFitInfo.create_from_fit(
+                omega,
+                mu_omega,
+                D_omega,
+                P,
+                K,
+                D_fit,
+                D_fit_inv,
+                block_structure,
+            )
+            error = mu_omega - d_scale_fit_info.mu_fit_omega
+            relative_error = np.max(error / np.max(mu_omega))
+            relative_errors.append(relative_error)
+            if (self.max_fit_order is not None) and (fit_order >= self.max_fit_order):
+                # TODO LOG
+                return int(np.argmin(relative_errors))
+            if relative_error > self.max_mu_fit_error:
+                fit_order += 1
+            else:
+                return fit_order
 
 
 def _augment_d_scales(


### PR DESCRIPTION
Resolves #10 

# Checklist

- [x] Write unit tests
- [x] Write examples in docstrings
- [x] Update Sphinx documentation
- [x] Bump version number and date in `pyproject.toml`, `doc/conf.py`,
      `README.rst`, and `CITATION.cff`.
